### PR TITLE
Identify total processors to allow Java to create enough threads for all cores

### DIFF
--- a/bootstrap/active_processors.sh
+++ b/bootstrap/active_processors.sh
@@ -1,0 +1,3 @@
+PROCESSORS=$( cat /proc/cpuinfo  | grep processor | wc -l )
+
+export ES_JAVA_OPTS="-XX:ActiveProcessorCount=${PROCESSORS} ${ES_JAVA_OPTS}"

--- a/docker-entrypoint-wrapper.sh
+++ b/docker-entrypoint-wrapper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source /root/bootstrap/*
+source <(cat /root/bootstrap/*)
 
 gomplate --file /usr/share/elasticsearch/config/elasticsearch.yml.gotpl \
          --datasource settings=file:///usr/share/elasticsearch/config/elasticsearch_custom.yml \


### PR DESCRIPTION
Java container support bases the active processors based on the CPU shares. When converted to Kubernetes, this means the requests are used to determine the number of processors instead of the limits. This can prevent more threads being created to match total processors.